### PR TITLE
updated the design vexriscv_uart to remove the unwanted remarks

### DIFF
--- a/Testcases/vexriscv_uart/bit_sim.sh
+++ b/Testcases/vexriscv_uart/bit_sim.sh
@@ -59,6 +59,8 @@ library=${raptor_path/$lib_fix_path//share/raptor/sim_models/rapidsilicon}
 
 [ ! -d $design_name\_golden ] && mkdir $design_name\_golden 
 
+python3 ../../scripts/init_path_update.py
+
 cd $design_name\_golden
 
 echo "create_design $design_name">raptor.tcl

--- a/Testcases/vexriscv_uart/rtl/vexriscv_uart.v
+++ b/Testcases/vexriscv_uart/rtl/vexriscv_uart.v
@@ -4557,7 +4557,7 @@ end
 // Port 0 | Read: Sync  | Write: ---- | 
 reg [31:0] rom[0:5721];
 initial begin
-	$readmemh("sim_rom.init", rom);
+	$readmemh("INIT_PATH/sim_rom.init", rom);
 end
 reg [31:0] rom_dat0;
 always @(posedge sys_clk_1) begin
@@ -4572,7 +4572,7 @@ assign main_simsoc_dat_r = rom_dat0;
 // Port 0 | Read: Sync  | Write: Sync | Mode: Write-First | Write-Granularity: 8 
 reg [31:0] sram[0:2047];
 initial begin
-	$readmemh("sim_sram.init", sram);
+	$readmemh("INIT_PATH/sim_sram.init", sram);
 end
 reg [10:0] sram_adr0;
 always @(posedge sys_clk_1) begin
@@ -4595,7 +4595,7 @@ assign main_ram_dat_r = sram[sram_adr0];
 // Port 0 | Read: Sync  | Write: ---- | 
 reg [7:0] mem[0:36];
 initial begin
-	$readmemh("sim_mem.init", mem);
+	$readmemh("INIT_PATH/sim_mem.init", mem);
 end
 reg [5:0] mem_adr0;
 always @(posedge sys_clk_1) begin

--- a/scripts/init_path_update.py
+++ b/scripts/init_path_update.py
@@ -1,0 +1,11 @@
+import os
+
+path=os.getcwd()+"/rtl"
+
+f = open("./rtl/vexriscv_uart.v",'r')
+file=f.read()
+file=file.replace("INIT_PATH",path)
+f.close()
+dos = open("./rtl/vexriscv_uart.v",'w+')
+dos.write(file)
+dos.close()


### PR DESCRIPTION
Added init_path_udpate.py script to make absolute path to .init files in rtl. 
Added INIT_PATH variable in vexriscv_uart.v to be replaced with current path using init_path_update.py script.