### PR TITLE
Use default congestion script

### DIFF
--- a/Testcases/canny_edge_detection/raptor.tcl
+++ b/Testcases/canny_edge_detection/raptor.tcl
@@ -1,0 +1,19 @@
+create_design canny_edge_detection_top
+target_device 1VG28
+add_include_path ./rtl
+add_library_path ./rtl
+add_library_ext .v .sv
+add_design_file ./rtl/ninerowsbuffer.vhd
+add_design_file ./rtl/krnl2.vhd
+add_design_file ./rtl/kernel.vhd
+add_design_file ./rtl/filterV.vhd
+add_design_file ./rtl/FIFOLineBuffer.vhd
+add_design_file ./rtl/DoubleLineBuffer.vhd
+add_design_file ./rtl/CacheSystem3.vhd
+add_design_file ./rtl/CacheSystem2.vhd
+add_design_file ./rtl/buffer.vhd
+add_design_file ./rtl/wrapper.vhd
+add_design_file ./rtl/top.vhd
+set_top_module top
+
+routability_flow


### PR DESCRIPTION
In ArchBench we want to profile the fabric performance, so "synthesize area" is not useful.
Moreover "synthesize area" goes typically against routability. That is why the routability flow is using synthesize delay.
Creating a my_routability_flow that is mixing both is hazardous.
If that flow needs to be experimented on, let's not do that in the ArchBench regression.


